### PR TITLE
fix elevator pivot points for World levels

### DIFF
--- a/src/assets/levels/World 1-1 v2.ldtk
+++ b/src/assets/levels/World 1-1 v2.ldtk
@@ -2433,7 +2433,7 @@
 			"maxCount": 0,
 			"limitScope": "PerLevel",
 			"limitBehavior": "MoveLastOne",
-			"pivotX": 0.5,
+			"pivotX": 0,
 			"pivotY": 0,
 			"fieldDefs": [
 				{

--- a/src/assets/levels/World 1-2 v1.ldtk
+++ b/src/assets/levels/World 1-2 v1.ldtk
@@ -2433,7 +2433,7 @@
 			"maxCount": 0,
 			"limitScope": "PerLevel",
 			"limitBehavior": "MoveLastOne",
-			"pivotX": 0.5,
+			"pivotX": 0,
 			"pivotY": 0,
 			"fieldDefs": [
 				{


### PR DESCRIPTION
it (the Elevator Enum pivot point) was correct in some levels, not in others -- I think it should be bet to the upper left so that where you drop it in the level editor is where it shows up in the level. without that pivot point change it is offset on the x axis